### PR TITLE
Copy gemspec before running bundle install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN bundle config --global frozen 1
 
 WORKDIR /usr/src/app
 
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock heimdallr.gemspec ./
 RUN bundle install
 
 COPY . .


### PR DESCRIPTION
Now gems are listed in the gemspec, not in the Gemfile.